### PR TITLE
Test glean.js click events

### DIFF
--- a/src/components/ActiveClients.js
+++ b/src/components/ActiveClients.js
@@ -16,6 +16,7 @@ import { formatDate } from '../lib/date';
 import { usePrevious } from '../lib/usePrevious';
 import { searchArrayElementPropertiesForSubstring } from '../lib/searchArrayElementPropertiesForSubstring';
 import { recordLoad, recordClick } from '../lib/telemetry';
+import GleanMetrics from '@mozilla/glean/metrics';
 
 const q = query(collection(getFirestore(), 'clients'), orderBy('lastActive', 'desc'));
 
@@ -141,15 +142,19 @@ const ActiveClients = () => {
                   <td>
                     <Link
                       className='text-decoration-none'
+                      data-glean-id={`/pings/${debugId}`}
+                      data-glean-type='Link'
+                      data-glean-label='Debug ID Pings'
                       to={`/pings/${debugId}`}
                       onClick={() => {
+                        GleanMetrics.recordElementClick({id: 'Explicit call'});
                         recordClick("Debug ID Pings");
                       }}
                     >
                       Pings
                     </Link>
                     <br />
-                    <Link className='text-decoration-none' to={`/stream/${debugId}`} onClick={() => {
+                    <Link className='text-decoration-none' data-glean-id={`/stream/${debugId}`} data-glean-label='Debug ID Event Stream' to={`/stream/${debugId}`} onClick={() => {
                       recordClick("Debug ID Event Stream")
                     }}>
                       Event Stream

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -20,7 +20,7 @@ function isTelemetryEnabled() {
   // If the app environment is not defined (likely because of local development),
   // then don't collect any data.
   if (typeof(process.env.REACT_APP_ENV) === "undefined") {
-    return false;
+    return true;
   }
 
   return navigator.doNotTrack !== '1';
@@ -35,7 +35,9 @@ export function initTelemetryClient(useSendBeacon=false) {
     maxEvents: 1,
     channel: process.env.REACT_APP_ENV,
     httpClient: useSendBeacon ? BrowserSendBeaconUploader : undefined,
+    enableAutoClickEvents: true,
   });
+  Glean.setDebugViewTag("abhi-auto");
 }
 
 /**

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -35,7 +35,7 @@ export function initTelemetryClient(useSendBeacon=false) {
     maxEvents: 1,
     channel: process.env.REACT_APP_ENV,
     httpClient: useSendBeacon ? BrowserSendBeaconUploader : undefined,
-    enableAutoClickEvents: true,
+    enableAutoElementClickEvents: true,
   });
   Glean.setDebugViewTag("abhi-auto");
 }


### PR DESCRIPTION
Testing https://github.com/mozilla/glean.js/pull/1848

Tests following scenarios:
1. Automatically recording clicks on "Pings" on home page
2. Manually recording clicks on "Pings" on home page
3. Automatically recording clicks on "Events" on home page where only some of the `data-glean-*` attributes are set